### PR TITLE
fix: usability fixes for real-world usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,8 @@ source .venv/bin/activate
 pip install -e '.[dev]'
 ```
 
+This is the canonical dev install method — all dependencies (including test and lint tools) are declared in `pyproject.toml`.
+
 ## Running Tests
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -36,23 +36,43 @@ Most AI code-review demos are either vague or overbuilt. `pr-reviewer` optimizes
 - Robust fallback when LLM returns malformed JSON
 - Structured logging with `--verbose` and `--debug` flags
 
-## Quickstart
+## Install
 
 ```bash
-python -m venv .venv
-source .venv/bin/activate
-pip install -e '.[dev]'
+pip install git+https://github.com/NoahLundSyrdal/prReviewer.git
 ```
+
+## Quickstart
+
+Set your API key:
+
+```bash
+export PR_REVIEWER_API_KEY="your-openai-api-key"
+```
+
+Review a diff:
+
+```bash
+git diff | pr-reviewer review --stdin
+```
+
+Review staged changes with multi-pass analysis:
+
+```bash
+pr-reviewer review --cached --mode multi
+```
+
+Review a patch file:
+
+```bash
+pr-reviewer review path/to/changes.patch --mode multi --format markdown --save review.md
+```
+
+## Core usage
 
 After installation, you can use either `pr-reviewer ...` or `python -m pr_reviewer ...`.
 
 `pr-reviewer` also supports repo-local defaults via `.pr-reviewer.toml` or `[tool.pr-reviewer]` in `pyproject.toml`.
-
-Required environment variable:
-
-```bash
-export PR_REVIEWER_API_KEY="your_api_key"
-```
 
 Optional model/provider settings:
 
@@ -61,49 +81,17 @@ export PR_REVIEWER_BASE_URL="https://api.openai.com/v1"
 export PR_REVIEWER_MODEL="gpt-4.1-mini"
 ```
 
-## Core usage
-
-Review a patch file:
-
-```bash
-python -m pr_reviewer review examples/travelsync_demo.patch --mode multi
-```
-
-Review current working diff:
-
-```bash
-git diff | python -m pr_reviewer review --stdin
-```
-
-Review staged changes:
-
-```bash
-python -m pr_reviewer review --cached
-```
-
-Run multi-pass review:
-
-```bash
-python -m pr_reviewer review examples/travelsync_demo.patch --mode multi
-```
-
 Compact terminal output:
 
 ```bash
-python -m pr_reviewer review examples/travelsync_demo.patch --mode multi --compact --color always
-```
-
-Save markdown output:
-
-```bash
-python -m pr_reviewer review examples/travelsync_demo.patch --mode multi --format markdown --save review.md
+pr-reviewer review examples/travelsync_demo.patch --mode multi --compact --color always
 ```
 
 Enable verbose logging:
 
 ```bash
-python -m pr_reviewer --verbose review --cached
-python -m pr_reviewer --debug review --cached
+pr-reviewer --verbose review --cached
+pr-reviewer --debug review --cached
 ```
 
 ## GitHub Action
@@ -131,7 +119,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - run: pip install pr-reviewer
+      - run: pip install git+https://github.com/NoahLundSyrdal/prReviewer.git
       - run: git diff origin/${{ github.event.pull_request.base.ref }}...HEAD > /tmp/pr.patch
       - name: Run review
         env:
@@ -254,10 +242,26 @@ pr_reviewer/
   models.py       # typed schema
 ```
 
-## Testing
+## Development
+
+```bash
+git clone https://github.com/NoahLundSyrdal/prReviewer.git
+cd prReviewer
+python -m venv .venv
+source .venv/bin/activate
+pip install -e '.[dev]'
+```
+
+Run tests:
 
 ```bash
 pytest -v
+```
+
+Lint:
+
+```bash
+ruff check .
 ```
 
 ## Known limitations

--- a/docs/github-action-setup.md
+++ b/docs/github-action-setup.md
@@ -4,7 +4,7 @@ Add automated LLM-powered PR reviews to your repository using the `pr-reviewer` 
 
 ## Quick Start
 
-1. Copy `.github/workflows/pr-review.yml` into your repository.
+1. Copy `examples/workflows/pr-review.yml` into your repo's `.github/workflows/` directory.
 2. Add the `PR_REVIEWER_API_KEY` secret to your repo (Settings > Secrets and variables > Actions).
 3. Open a pull request — the review will run automatically.
 
@@ -47,7 +47,7 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install pr-reviewer
-        run: pip install pr-reviewer
+        run: pip install git+https://github.com/NoahLundSyrdal/prReviewer.git
       - name: Get PR diff
         run: |
           git diff origin/${{ github.event.pull_request.base.ref }}...HEAD > /tmp/pr.patch

--- a/examples/workflows/pr-review.yml
+++ b/examples/workflows/pr-review.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install pr-reviewer
-        run: pip install pr-reviewer
+        run: pip install git+https://github.com/NoahLundSyrdal/prReviewer.git
       - name: Get PR diff
         run: |
           git diff origin/${{ github.event.pull_request.base.ref }}...HEAD > /tmp/pr.patch

--- a/pr_reviewer/cli.py
+++ b/pr_reviewer/cli.py
@@ -318,7 +318,7 @@ def run_review(args: argparse.Namespace) -> int:
             logger.error("could not save output to %s: %s", output_path, exc)
             return 1
 
-        logger.info("Saved output to %s", output_path)
+        print(f"Saved output to {output_path}", file=sys.stderr)
 
     if args.post:
         from .integrations import IntegrationError, post_findings
@@ -428,16 +428,13 @@ def _validate_post_args(args: argparse.Namespace) -> str | None:
 
 def _print_posting_report(*, report, dry_run: bool) -> None:
     mode = "dry-run posted" if dry_run else "posted"
-    logger.info(
-        "%s comments %s: %d/%d (skipped: %d)",
-        report.platform,
-        mode,
-        report.posted,
-        report.attempted,
-        report.skipped,
+    print(
+        f"{report.platform} comments {mode}: {report.posted}/{report.attempted} "
+        f"(skipped: {report.skipped})",
+        file=sys.stderr,
     )
     for error in report.errors[:8]:
-        logger.warning("%s", error)
+        print(f"  - {error}", file=sys.stderr)
 
 
 def _extract_config_arg(argv: list[str]) -> str | None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-pydantic>=2.6,<3
-requests>=2.31,<3
-pytest>=8.0,<9


### PR DESCRIPTION
## Summary

- **Fix install command everywhere**: Replace `pip install pr-reviewer` (not on PyPI) with `pip install git+https://github.com/NoahLundSyrdal/prReviewer.git` in README, docs/github-action-setup.md, and the example workflow
- **Move workflow to examples/**: Move `pr-review.yml` from `.github/workflows/` to `examples/workflows/` so it doesn't trigger (and fail) on PRs to the repo itself. Updated docs to reference the new location.
- **Fix silent posting report**: Change `_print_posting_report` and save confirmation from `logger.info` to `print(file=sys.stderr)` so users always see posting feedback without needing `--verbose`
- **Rewrite README quickstart**: Lead with one-liner pip install and common usage patterns instead of dev clone workflow. Dev setup moved to a "Development" section at the bottom.
- **Delete stale requirements.txt**: Removed (pyproject.toml is the source of truth). Added clarifying note in CONTRIBUTING.md.

## Test plan

- [x] `ruff check .` — all checks passed
- [x] `pytest -v` — all 56 tests pass
- [x] Verify install command works: `pip install git+https://github.com/NoahLundSyrdal/prReviewer.git`
- [x] Verify posting report is visible without `--verbose` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)