### PR TITLE
fix: address all three known limitations (context, schema, fallback)

### DIFF
--- a/pr_reviewer/cli.py
+++ b/pr_reviewer/cli.py
@@ -293,20 +293,23 @@ def run_review(args: argparse.Namespace) -> int:
         logger.error("empty diff input")
         return 2
 
-    # Auto-fetch file context when posting to GitHub (we have repo + PR number)
+    # Auto-fetch file + project context when posting to GitHub (we have repo + PR number)
     file_context: dict[str, str] | None = None
+    project_context: dict[str, str] | None = None
     if args.post == "github" and args.repo and args.pr and not getattr(args, "no_context", False):
-        from .context import fetch_github_file_context
+        from .context import fetch_github_file_context, fetch_project_context
         from .parsing import parse_diff_stats
 
+        # Resolve PR head SHA for accurate file fetching
+        ref = _resolve_github_head_sha(
+            repo=args.repo,
+            pr_number=args.pr,
+            token=args.integration_token,
+        )
+
+        # Per-file context: full content of each changed file
         file_paths = parse_diff_stats(diff_text).files
         if file_paths:
-            # Resolve head SHA for accuracy
-            ref = _resolve_github_head_sha(
-                repo=args.repo,
-                pr_number=args.pr,
-                token=args.integration_token,
-            )
             file_context = fetch_github_file_context(
                 repo=args.repo,
                 file_paths=file_paths,
@@ -315,6 +318,15 @@ def run_review(args: argparse.Namespace) -> int:
             )
             if file_context:
                 logger.info("Fetched file context for %d file(s)", len(file_context))
+
+        # Project context: README, conventions, config manifest
+        project_context = fetch_project_context(
+            repo=args.repo,
+            ref=ref,
+            token=args.integration_token,
+        )
+        if project_context:
+            logger.info("Fetched project context: %s", ", ".join(project_context.keys()))
 
     try:
         provider = OpenAICompatibleProvider(base_url=args.base_url)
@@ -325,6 +337,7 @@ def run_review(args: argparse.Namespace) -> int:
             max_lines=args.max_lines,
             review_mode=args.mode,
             file_context=file_context,
+            project_context=project_context,
         )
     except (ProviderConfigError, LLMError) as exc:
         logger.error("%s", exc)

--- a/pr_reviewer/cli.py
+++ b/pr_reviewer/cli.py
@@ -9,6 +9,8 @@ import tomllib
 from pathlib import Path
 from textwrap import dedent
 
+import requests
+
 from . import __version__
 from .formatters import format_review
 from .llm import LLMError, OpenAICompatibleProvider, ProviderConfigError
@@ -243,6 +245,12 @@ def build_parser(*, review_defaults: dict[str, object] | None = None) -> argpars
         default=defaults["dry_run_post"],
         help="Simulate posting without making network calls",
     )
+    review_parser.add_argument(
+        "--no-context",
+        action="store_true",
+        default=False,
+        help="Skip automatic file context fetching (fetched by default when --post github is used)",
+    )
 
     return parser
 
@@ -285,6 +293,29 @@ def run_review(args: argparse.Namespace) -> int:
         logger.error("empty diff input")
         return 2
 
+    # Auto-fetch file context when posting to GitHub (we have repo + PR number)
+    file_context: dict[str, str] | None = None
+    if args.post == "github" and args.repo and args.pr and not getattr(args, "no_context", False):
+        from .context import fetch_github_file_context
+        from .parsing import parse_diff_stats
+
+        file_paths = parse_diff_stats(diff_text).files
+        if file_paths:
+            # Resolve head SHA for accuracy
+            ref = _resolve_github_head_sha(
+                repo=args.repo,
+                pr_number=args.pr,
+                token=args.integration_token,
+            )
+            file_context = fetch_github_file_context(
+                repo=args.repo,
+                file_paths=file_paths,
+                ref=ref,
+                token=args.integration_token,
+            )
+            if file_context:
+                logger.info("Fetched file context for %d file(s)", len(file_context))
+
     try:
         provider = OpenAICompatibleProvider(base_url=args.base_url)
         reviewer = PRReviewer(provider)
@@ -293,6 +324,7 @@ def run_review(args: argparse.Namespace) -> int:
             model=args.model,
             max_lines=args.max_lines,
             review_mode=args.mode,
+            file_context=file_context,
         )
     except (ProviderConfigError, LLMError) as exc:
         logger.error("%s", exc)
@@ -424,6 +456,35 @@ def _validate_post_args(args: argparse.Namespace) -> str | None:
         return "--post gitlab does not accept --pr"
 
     return None
+
+
+def _resolve_github_head_sha(
+    *,
+    repo: str,
+    pr_number: int,
+    token: str | None,
+) -> str:
+    """Fetch the head SHA of a GitHub PR. Falls back to 'HEAD' on error."""
+    token = token or os.getenv("GITHUB_TOKEN")
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    try:
+        resp = requests.get(
+            f"https://api.github.com/repos/{repo}/pulls/{pr_number}",
+            headers=headers,
+            timeout=(10, 30),
+        )
+        if resp.status_code == 200:
+            sha = resp.json().get("head", {}).get("sha")
+            if sha:
+                return sha
+    except requests.RequestException as exc:
+        logger.debug("Could not resolve PR head SHA: %s", exc)
+    return "HEAD"
 
 
 def _print_posting_report(*, report, dry_run: bool) -> None:

--- a/pr_reviewer/context.py
+++ b/pr_reviewer/context.py
@@ -13,6 +13,30 @@ _READ_TIMEOUT = 30
 _REQUEST_TIMEOUT = (_CONNECT_TIMEOUT, _READ_TIMEOUT)
 _MAX_FILE_LINES = 300
 
+# Project-level files fetched once per review to give the model broader context.
+# Ordered by priority — first match wins within each group.
+_PROJECT_CONTEXT_CANDIDATES: list[tuple[str, int]] = [
+    # Project description / purpose (most valuable — tells the model what it's reviewing)
+    ("README.md", 150),
+    ("README.rst", 150),
+    ("README", 100),
+    # Conventions / contribution guidelines
+    ("CONTRIBUTING.md", 80),
+    ("AGENTS.md", 80),
+    ("DEVELOPMENT.md", 80),
+    # Architecture / design docs (first found wins)
+    ("docs/architecture.md", 100),
+    ("docs/ARCHITECTURE.md", 100),
+    ("docs/design.md", 80),
+    # Primary package/config manifest (reveals language, deps, tooling)
+    ("pyproject.toml", 60),
+    ("package.json", 60),
+    ("go.mod", 40),
+    ("Cargo.toml", 40),
+    ("pom.xml", 40),
+    ("build.gradle", 40),
+]
+
 
 def fetch_github_file_context(
     *,
@@ -68,4 +92,97 @@ def fetch_github_file_context(
         context[path] = content
 
     logger.debug("Fetched file context for %d/%d files", len(context), len(file_paths))
+    return context
+
+
+def fetch_project_context(
+    *,
+    repo: str,
+    ref: str,
+    token: str | None,
+    base_url: str = "https://api.github.com",
+    candidates: list[tuple[str, int]] | None = None,
+) -> dict[str, str]:
+    """Fetch project-level context files (README, conventions, config manifest).
+
+    Returns a dict of {path: truncated_content} for whichever candidates exist.
+    Files are fetched in candidate order; each has its own line cap.
+    Failures are silently skipped.
+    """
+    token = token or os.getenv("GITHUB_TOKEN")
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    if candidates is None:
+        candidates = _PROJECT_CONTEXT_CANDIDATES
+
+    context: dict[str, str] = {}
+    session = requests.Session()
+    session.headers.update(headers)
+
+    # Group candidates by their "role" so we stop after the first hit per group.
+    # Groups are defined by sequential runs of the same comment block above each entry.
+    # Simpler heuristic: stop after first README hit, first CONTRIBUTING hit, etc.
+    # We implement this by tracking which prefix groups have been satisfied.
+    _readme_done = False
+    _contributing_done = False
+    _arch_done = False
+    _manifest_done = False
+
+    for path, max_lines in candidates:
+        # Skip if this group already has a hit
+        lower = path.lower()
+        if lower.startswith("readme") and _readme_done:
+            continue
+        if any(k in lower for k in ("contributing", "agents", "development")) and _contributing_done:
+            continue
+        if "docs/" in lower and _arch_done:
+            continue
+        if any(lower.endswith(ext) for ext in (".toml", ".json", ".mod", ".gradle", ".xml")) and _manifest_done:
+            continue
+
+        url = f"{base_url.rstrip('/')}/repos/{repo}/contents/{path}"
+        try:
+            resp = session.get(url, params={"ref": ref}, timeout=_REQUEST_TIMEOUT)
+        except requests.RequestException as exc:
+            logger.debug("Failed to fetch project context for %s: %s", path, exc)
+            continue
+
+        if resp.status_code == 404:
+            continue
+        if resp.status_code >= 400:
+            logger.debug("GitHub returned %d fetching project context %s", resp.status_code, path)
+            continue
+
+        try:
+            data = resp.json()
+            content_b64 = data.get("content", "")
+            if not content_b64:
+                continue
+            content = base64.b64decode(content_b64.replace("\n", "")).decode("utf-8", errors="replace")
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Failed to decode project context for %s: %s", path, exc)
+            continue
+
+        lines = content.splitlines()
+        if len(lines) > max_lines:
+            content = "\n".join(lines[:max_lines]) + f"\n# ... truncated at {max_lines} lines ..."
+
+        context[path] = content
+
+        # Mark this group as satisfied
+        if lower.startswith("readme"):
+            _readme_done = True
+        elif any(k in lower for k in ("contributing", "agents", "development")):
+            _contributing_done = True
+        elif "docs/" in lower:
+            _arch_done = True
+        else:
+            _manifest_done = True
+
+    logger.debug("Fetched project context: %s", list(context.keys()))
     return context

--- a/pr_reviewer/context.py
+++ b/pr_reviewer/context.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import base64
+import logging
+import os
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+_CONNECT_TIMEOUT = 10
+_READ_TIMEOUT = 30
+_REQUEST_TIMEOUT = (_CONNECT_TIMEOUT, _READ_TIMEOUT)
+_MAX_FILE_LINES = 300
+
+
+def fetch_github_file_context(
+    *,
+    repo: str,
+    file_paths: list[str],
+    ref: str,
+    token: str | None,
+    base_url: str = "https://api.github.com",
+) -> dict[str, str]:
+    """Fetch full file content from GitHub API. Returns {path: content}. Silently skips failures."""
+    token = token or os.getenv("GITHUB_TOKEN")
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    context: dict[str, str] = {}
+    session = requests.Session()
+    session.headers.update(headers)
+
+    for path in file_paths:
+        url = f"{base_url.rstrip('/')}/repos/{repo}/contents/{path}"
+        try:
+            resp = session.get(url, params={"ref": ref}, timeout=_REQUEST_TIMEOUT)
+        except requests.RequestException as exc:
+            logger.debug("Failed to fetch context for %s: %s", path, exc)
+            continue
+
+        if resp.status_code == 404:
+            # File may be deleted in this PR — skip silently
+            continue
+
+        if resp.status_code >= 400:
+            logger.debug("GitHub returned %d for %s", resp.status_code, path)
+            continue
+
+        try:
+            data = resp.json()
+            content_b64 = data.get("content", "")
+            if not content_b64:
+                continue
+            content = base64.b64decode(content_b64.replace("\n", "")).decode("utf-8", errors="replace")
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Failed to decode context for %s: %s", path, exc)
+            continue
+
+        lines = content.splitlines()
+        if len(lines) > _MAX_FILE_LINES:
+            content = "\n".join(lines[:_MAX_FILE_LINES]) + f"\n# ... truncated at {_MAX_FILE_LINES} lines ..."
+
+        context[path] = content
+
+    logger.debug("Fetched file context for %d/%d files", len(context), len(file_paths))
+    return context

--- a/pr_reviewer/integrations.py
+++ b/pr_reviewer/integrations.py
@@ -30,6 +30,7 @@ class PostingReport:
     attempted: int = 0
     posted: int = 0
     skipped: int = 0
+    fallback_posted: int = 0
     errors: list[str] = field(default_factory=list)
 
 
@@ -131,6 +132,7 @@ def _post_to_github(
     if not head_sha:
         raise IntegrationError("Could not resolve GitHub PR head SHA.")
 
+    postable_with_status: list[tuple[ReviewFinding, CommentTarget, bool]] = []
     for finding, target in postable_findings:
         report.attempted += 1
 
@@ -144,19 +146,38 @@ def _post_to_github(
 
         if response.status_code in {200, 201}:
             report.posted += 1
+            postable_with_status.append((finding, target, False))
             continue
 
         if response.status_code == 422:
             report.skipped += 1
             report.errors.append(
-                f"Skipped {finding.file}:{finding.line} ({finding.title}): GitHub rejected comment position."
+                f"Skipped {finding.file}:{finding.line} ({finding.title}): "
+                "inline position rejected, will try fallback."
             )
+            postable_with_status.append((finding, target, True))
             continue
 
         report.errors.append(
             f"GitHub comment failed for {finding.file}:{finding.line} ({finding.title}) "
             f"[{response.status_code}]."
         )
+        postable_with_status.append((finding, target, False))
+
+    # Post fallback summary for 422-rejected findings
+    fallback_findings = [(f, t) for f, t, had_422 in postable_with_status if had_422]
+    if fallback_findings:
+        body = _build_fallback_summary_body(fallback_findings)
+        issues_url = f"{base_url.rstrip('/')}/repos/{repo}/issues/{pr_number}/comments"
+        fb_response = session.post(issues_url, json={"body": body}, timeout=_REQUEST_TIMEOUT)
+        if fb_response.status_code in {200, 201}:
+            report.fallback_posted += len(fallback_findings)
+            report.posted += len(fallback_findings)
+            report.skipped -= len(fallback_findings)
+            # Clean up the "will try fallback" error messages
+            report.errors = [e for e in report.errors if "will try fallback" not in e]
+        else:
+            report.errors.append(f"Fallback summary comment failed [{fb_response.status_code}].")
 
     logger.info("GitHub posting complete: %d/%d posted, %d skipped", report.posted, report.attempted, report.skipped)
     return report
@@ -359,6 +380,32 @@ def _build_gitlab_comment_payload(
         "body": _build_comment_body(finding),
         "position": position,
     }
+
+
+def _build_fallback_summary_body(
+    findings_with_targets: list[tuple[ReviewFinding, CommentTarget]],
+) -> str:
+    lines = ["## PR Review — Findings (could not post as inline comments)\n"]
+    lines.append(
+        "The following findings could not be posted as inline comments"
+        " (the diff position may have changed). They are summarized here instead.\n"
+    )
+    for finding, target in findings_with_targets:
+        location = (
+            f"`{target.file_path}:{finding.line}`"
+            if finding.line
+            else f"`{target.file_path}`"
+        )
+        lines.append(
+            f"### [{finding.severity.value.upper()}][{finding.category.value}] {finding.title}\n"
+            f"**Location**: {location}  \n"
+            f"**Confidence**: {finding.confidence:.2f}  \n"
+            f"**Why it matters**: {finding.explanation}\n"
+        )
+        if finding.suggested_fix:
+            lines.append(f"**Suggested fix**: {finding.suggested_fix}\n")
+        lines.append("")
+    return "\n".join(lines)
 
 
 def _build_comment_body(finding: ReviewFinding) -> str:

--- a/pr_reviewer/llm.py
+++ b/pr_reviewer/llm.py
@@ -22,7 +22,14 @@ class LLMError(RuntimeError):
 
 
 class LLMProvider(Protocol):
-    def complete_json(self, *, model: str, system_prompt: str, user_prompt: str) -> str:
+    def complete_json(
+        self,
+        *,
+        model: str,
+        system_prompt: str,
+        user_prompt: str,
+        json_schema: dict | None = None,
+    ) -> str:
         ...
 
 
@@ -48,12 +55,32 @@ class OpenAICompatibleProvider:
             or default_base_url
         ).rstrip("/")
 
-    def complete_json(self, *, model: str, system_prompt: str, user_prompt: str) -> str:
+    def complete_json(
+        self,
+        *,
+        model: str,
+        system_prompt: str,
+        user_prompt: str,
+        json_schema: dict | None = None,
+    ) -> str:
         url = f"{self.base_url}/chat/completions"
+
+        if json_schema:
+            response_format = {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "review_result",
+                    "strict": True,
+                    "schema": json_schema,
+                },
+            }
+        else:
+            response_format = {"type": "json_object"}
+
         payload = {
             "model": model,
             "temperature": 0.1,
-            "response_format": {"type": "json_object"},
+            "response_format": response_format,
             "messages": [
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": user_prompt},
@@ -97,6 +124,15 @@ class OpenAICompatibleProvider:
 
             elapsed = time.monotonic() - t0
             logger.debug("LLM response %d in %.2fs", response.status_code, elapsed)
+
+            # Graceful fallback: if json_schema mode gets 400, retry with json_object
+            if response.status_code == 400 and json_schema and payload["response_format"]["type"] == "json_schema":
+                logger.warning(
+                    "Provider returned 400 with json_schema mode; "
+                    "falling back to json_object response_format."
+                )
+                payload["response_format"] = {"type": "json_object"}
+                continue
 
             if response.status_code in {429, 500, 502, 503, 504} and attempt < attempts:
                 retry_after = response.headers.get("Retry-After")

--- a/pr_reviewer/reviewer.py
+++ b/pr_reviewer/reviewer.py
@@ -148,6 +148,7 @@ class PRReviewer:
         max_lines: int = 1200,
         review_mode: str = "single",
         file_context: dict[str, str] | None = None,
+        project_context: dict[str, str] | None = None,
     ) -> ReviewResult:
         if review_mode not in {"single", "multi"}:
             raise ValueError("review_mode must be 'single' or 'multi'")
@@ -176,6 +177,7 @@ class PRReviewer:
                 model=model,
                 warnings=warnings,
                 file_context=file_context,
+                project_context=project_context,
             )
 
         return self._review_single(
@@ -185,6 +187,7 @@ class PRReviewer:
             model=model,
             warnings=warnings,
             file_context=file_context,
+            project_context=project_context,
         )
 
     def _review_single(
@@ -196,6 +199,7 @@ class PRReviewer:
         model: str,
         warnings: list[str],
         file_context: dict[str, str] | None = None,
+        project_context: dict[str, str] | None = None,
     ) -> ReviewResult:
         payloads: list[LLMReviewPayload] = []
         chunk_reviews: list[dict[str, object]] = []
@@ -217,6 +221,7 @@ class PRReviewer:
                 chunk_index=chunk_index,
                 chunk_count=chunk_count,
                 file_context=file_context,
+                project_context=project_context,
             )
 
             if parse_warning:
@@ -329,6 +334,7 @@ class PRReviewer:
         model: str,
         warnings: list[str],
         file_context: dict[str, str] | None = None,
+        project_context: dict[str, str] | None = None,
     ) -> ReviewResult:
         payloads: list[tuple[str, LLMReviewPayload]] = []
         chunk_reviews: list[dict[str, object]] = []
@@ -350,6 +356,7 @@ class PRReviewer:
                     chunk_index=chunk_index,
                     chunk_count=chunk_count,
                     file_context=file_context,
+                    project_context=project_context,
                 )
 
                 if parse_warning:
@@ -467,6 +474,7 @@ class PRReviewer:
         chunk_index: int,
         chunk_count: int,
         file_context: dict[str, str] | None = None,
+        project_context: dict[str, str] | None = None,
     ) -> tuple[LLMReviewPayload | None, str, str | None]:
         logger.debug(
             "Running pass=%s model=%s chunk=%d/%d lines=%d",
@@ -485,6 +493,7 @@ class PRReviewer:
             chunk_index=chunk_index,
             chunk_count=chunk_count,
             file_context=file_context,
+            project_context=project_context,
         )
 
         try:
@@ -512,6 +521,7 @@ class PRReviewer:
         chunk_index: int,
         chunk_count: int,
         file_context: dict[str, str] | None = None,
+        project_context: dict[str, str] | None = None,
     ) -> str:
         files_block = "\n".join(f"- {name}" for name in stats.files[:50])
         if not files_block:
@@ -529,6 +539,16 @@ class PRReviewer:
                 f"- Chunk files changed: {stats.files_changed}\n"
                 f"- Chunk visible diff lines: {stats.line_count}\n\n"
             )
+
+        project_block = ""
+        if project_context:
+            parts = [
+                "Project context (README, conventions, config — use to understand what this project"
+                " does and how it is structured):\n"
+            ]
+            for path, content in project_context.items():
+                parts.append(f"=== {path} ===\n{content}\n=== end {path} ===\n")
+            project_block = "\n".join(parts) + "\n"
 
         context_block = ""
         if file_context:
@@ -561,6 +581,7 @@ class PRReviewer:
             "- Avoid duplicate findings; include only meaningful issues for this pass.\n"
             "- If this is one chunk of a larger diff, do not speculate about code outside this chunk.\n"
             "- If uncertain, lower confidence instead of overstating.\n\n"
+            f"{project_block}"
             f"{context_block}"
             "DIFF_START\n"
             f"{diff_text}\n"

--- a/pr_reviewer/reviewer.py
+++ b/pr_reviewer/reviewer.py
@@ -71,6 +71,44 @@ JSON schema:
 }
 """
 
+REVIEW_JSON_SCHEMA: dict = {
+    "type": "object",
+    "properties": {
+        "summary": {"type": "string"},
+        "verdict": {"type": "string", "enum": ["looks good", "needs attention", "high risk"]},
+        "findings": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "severity": {"type": "string", "enum": ["low", "medium", "high"]},
+                    "category": {"type": "string", "enum": ["bug", "security", "performance", "maintainability"]},
+                    "title": {"type": "string"},
+                    "explanation": {"type": "string"},
+                    "file": {"type": ["string", "null"]},
+                    "line": {"type": ["integer", "null"]},
+                    "confidence": {"type": "number"},
+                    "suggested_fix": {"type": ["string", "null"]},
+                },
+                "required": ["severity", "category", "title", "explanation", "confidence"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    "required": ["summary", "verdict", "findings"],
+    "additionalProperties": False,
+}
+
+SYNTHESIS_JSON_SCHEMA: dict = {
+    "type": "object",
+    "properties": {
+        "summary": {"type": "string"},
+        "verdict": {"type": "string", "enum": ["looks good", "needs attention", "high risk"]},
+    },
+    "required": ["summary", "verdict"],
+    "additionalProperties": False,
+}
+
 MULTI_PASS_FOCI: list[tuple[str, str]] = [
     (
         "correctness",
@@ -445,6 +483,7 @@ class PRReviewer:
                 model=model,
                 system_prompt=SYSTEM_PROMPT,
                 user_prompt=user_prompt,
+                json_schema=REVIEW_JSON_SCHEMA,
             )
         except LLMError as exc:
             logger.warning("LLM call failed for pass=%s chunk=%d/%d: %s", pass_name, chunk_index, chunk_count, exc)
@@ -548,6 +587,7 @@ class PRReviewer:
             model=model,
             system_prompt=SYNTHESIS_SYSTEM_PROMPT,
             user_prompt=user_prompt,
+            json_schema=SYNTHESIS_JSON_SCHEMA,
         )
 
         payload, parse_warning = _parse_synthesis_payload(raw_response)

--- a/pr_reviewer/reviewer.py
+++ b/pr_reviewer/reviewer.py
@@ -109,6 +109,7 @@ class PRReviewer:
         model: str,
         max_lines: int = 1200,
         review_mode: str = "single",
+        file_context: dict[str, str] | None = None,
     ) -> ReviewResult:
         if review_mode not in {"single", "multi"}:
             raise ValueError("review_mode must be 'single' or 'multi'")
@@ -136,6 +137,7 @@ class PRReviewer:
                 stats=stats,
                 model=model,
                 warnings=warnings,
+                file_context=file_context,
             )
 
         return self._review_single(
@@ -144,6 +146,7 @@ class PRReviewer:
             stats=stats,
             model=model,
             warnings=warnings,
+            file_context=file_context,
         )
 
     def _review_single(
@@ -154,6 +157,7 @@ class PRReviewer:
         stats: DiffStats,
         model: str,
         warnings: list[str],
+        file_context: dict[str, str] | None = None,
     ) -> ReviewResult:
         payloads: list[LLMReviewPayload] = []
         chunk_reviews: list[dict[str, object]] = []
@@ -174,6 +178,7 @@ class PRReviewer:
                 full_stats=stats,
                 chunk_index=chunk_index,
                 chunk_count=chunk_count,
+                file_context=file_context,
             )
 
             if parse_warning:
@@ -285,6 +290,7 @@ class PRReviewer:
         stats: DiffStats,
         model: str,
         warnings: list[str],
+        file_context: dict[str, str] | None = None,
     ) -> ReviewResult:
         payloads: list[tuple[str, LLMReviewPayload]] = []
         chunk_reviews: list[dict[str, object]] = []
@@ -305,6 +311,7 @@ class PRReviewer:
                     full_stats=stats,
                     chunk_index=chunk_index,
                     chunk_count=chunk_count,
+                    file_context=file_context,
                 )
 
                 if parse_warning:
@@ -421,6 +428,7 @@ class PRReviewer:
         full_stats: DiffStats,
         chunk_index: int,
         chunk_count: int,
+        file_context: dict[str, str] | None = None,
     ) -> tuple[LLMReviewPayload | None, str, str | None]:
         logger.debug(
             "Running pass=%s model=%s chunk=%d/%d lines=%d",
@@ -438,6 +446,7 @@ class PRReviewer:
             focus=focus,
             chunk_index=chunk_index,
             chunk_count=chunk_count,
+            file_context=file_context,
         )
 
         try:
@@ -463,6 +472,7 @@ class PRReviewer:
         focus: str,
         chunk_index: int,
         chunk_count: int,
+        file_context: dict[str, str] | None = None,
     ) -> str:
         files_block = "\n".join(f"- {name}" for name in stats.files[:50])
         if not files_block:
@@ -480,6 +490,19 @@ class PRReviewer:
                 f"- Chunk files changed: {stats.files_changed}\n"
                 f"- Chunk visible diff lines: {stats.line_count}\n\n"
             )
+
+        context_block = ""
+        if file_context:
+            chunk_files = set(stats.files)
+            relevant = {p: c for p, c in file_context.items() if p in chunk_files}
+            if relevant:
+                parts = [
+                    "File context (full current content of changed files — use to understand broader"
+                    " structure, but only flag issues that are visible in the diff below):\n"
+                ]
+                for path, content in list(relevant.items())[:10]:
+                    parts.append(f"=== {path} ===\n{content}\n=== end {path} ===\n")
+                context_block = "\n".join(parts) + "\n"
 
         return (
             "Review this unified diff and return JSON using the required schema.\n\n"
@@ -499,6 +522,7 @@ class PRReviewer:
             "- Avoid duplicate findings; include only meaningful issues for this pass.\n"
             "- If this is one chunk of a larger diff, do not speculate about code outside this chunk.\n"
             "- If uncertain, lower confidence instead of overstating.\n\n"
+            f"{context_block}"
             "DIFF_START\n"
             f"{diff_text}\n"
             "DIFF_END"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,7 +101,9 @@ class FakeProvider:
         self._idx = 0
         self.prompts: list[str] = []
 
-    def complete_json(self, *, model: str, system_prompt: str, user_prompt: str) -> str:
+    def complete_json(
+        self, *, model: str, system_prompt: str, user_prompt: str, json_schema: dict | None = None
+    ) -> str:
         self.prompts.append(user_prompt)
         response = self._responses[self._idx]
         self._idx += 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -144,6 +144,7 @@ def test_main_reads_patch_and_saves_output(
         "max_lines": 1200,
         "review_mode": "single",
         "file_context": None,
+        "project_context": None,
     }
 
 
@@ -219,6 +220,7 @@ def test_main_loads_defaults_from_dot_pr_reviewer_toml(
         "max_lines": 77,
         "review_mode": "multi",
         "file_context": None,
+        "project_context": None,
     }
     assert calls["format_kwargs"] == {
         "output_format": "text",
@@ -277,6 +279,7 @@ def test_main_loads_pyproject_config_but_cli_flags_override(
         "max_lines": 88,
         "review_mode": "single",
         "file_context": None,
+        "project_context": None,
     }
     assert calls["format_kwargs"] == {
         "output_format": "json",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -143,6 +143,7 @@ def test_main_reads_patch_and_saves_output(
         "model": "gpt-4.1-mini",
         "max_lines": 1200,
         "review_mode": "single",
+        "file_context": None,
     }
 
 
@@ -217,6 +218,7 @@ def test_main_loads_defaults_from_dot_pr_reviewer_toml(
         "model": "config-model",
         "max_lines": 77,
         "review_mode": "multi",
+        "file_context": None,
     }
     assert calls["format_kwargs"] == {
         "output_format": "text",
@@ -274,6 +276,7 @@ def test_main_loads_pyproject_config_but_cli_flags_override(
         "model": "cli-model",
         "max_lines": 88,
         "review_mode": "single",
+        "file_context": None,
     }
     assert calls["format_kwargs"] == {
         "output_format": "json",

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import requests
 
-from pr_reviewer.context import _MAX_FILE_LINES, fetch_github_file_context
+from pr_reviewer.context import _MAX_FILE_LINES, fetch_github_file_context, fetch_project_context
 
 
 def _b64(content: str) -> str:
@@ -191,3 +191,93 @@ class TestFetchGithubFileContext:
         assert "src/x.py" in result
         call_kwargs = session.headers.update.call_args[0][0]
         assert "Authorization" not in call_kwargs
+
+
+# ---------------------------------------------------------------------------
+# fetch_project_context
+# ---------------------------------------------------------------------------
+
+
+class TestFetchProjectContext:
+    def test_fetches_readme_and_config(self) -> None:
+        readme_content = "# My Project\nDoes cool stuff."
+        config_content = "[tool.myapp]\nversion = '1.0'"
+
+        def _get_side_effect(url, **kwargs):
+            if "README.md" in url:
+                return _mock_response(200, {"content": _b64(readme_content)})
+            if "pyproject.toml" in url:
+                return _mock_response(200, {"content": _b64(config_content)})
+            return _mock_response(404)
+
+        with patch("pr_reviewer.context.requests.Session") as mock_session_cls:
+            session = MagicMock()
+            session.get.side_effect = _get_side_effect
+            mock_session_cls.return_value = session
+
+            result = fetch_project_context(repo="owner/repo", ref="main", token="tok")
+
+        assert "README.md" in result
+        assert readme_content in result["README.md"]
+
+    def test_stops_after_first_readme_hit(self) -> None:
+        """Should not fetch README.rst if README.md succeeded."""
+        readme_md_content = "# Found me"
+
+        call_log: list[str] = []
+
+        def _get_side_effect(url, **kwargs):
+            call_log.append(url)
+            if "README.md" in url:
+                return _mock_response(200, {"content": _b64(readme_md_content)})
+            return _mock_response(404)
+
+        with patch("pr_reviewer.context.requests.Session") as mock_session_cls:
+            session = MagicMock()
+            session.get.side_effect = _get_side_effect
+            mock_session_cls.return_value = session
+
+            result = fetch_project_context(repo="owner/repo", ref="main", token="tok")
+
+        assert "README.md" in result
+        assert not any("README.rst" in url for url in call_log), "README.rst should not be fetched after README.md hit"
+
+    def test_truncates_at_per_file_line_cap(self) -> None:
+        # README.md has a cap of 150 lines
+        lines = [f"line {i}" for i in range(200)]
+        content = "\n".join(lines)
+
+        with patch("pr_reviewer.context.requests.Session") as mock_session_cls:
+            session = MagicMock()
+            session.get.return_value = _mock_response(200, {"content": _b64(content)})
+            mock_session_cls.return_value = session
+
+            result = fetch_project_context(
+                repo="owner/repo",
+                ref="main",
+                token="tok",
+                candidates=[("README.md", 150)],
+            )
+
+        assert "README.md" in result
+        assert "truncated at 150 lines" in result["README.md"]
+
+    def test_all_404_returns_empty(self) -> None:
+        with patch("pr_reviewer.context.requests.Session") as mock_session_cls:
+            session = MagicMock()
+            session.get.return_value = _mock_response(404)
+            mock_session_cls.return_value = session
+
+            result = fetch_project_context(repo="owner/repo", ref="main", token=None)
+
+        assert result == {}
+
+    def test_network_error_skipped(self) -> None:
+        with patch("pr_reviewer.context.requests.Session") as mock_session_cls:
+            session = MagicMock()
+            session.get.side_effect = requests.ConnectionError("down")
+            mock_session_cls.return_value = session
+
+            result = fetch_project_context(repo="owner/repo", ref="main", token=None)
+
+        assert result == {}

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,193 @@
+"""Tests for pr_reviewer.context."""
+from __future__ import annotations
+
+import base64
+from unittest.mock import MagicMock, patch
+
+import requests
+
+from pr_reviewer.context import _MAX_FILE_LINES, fetch_github_file_context
+
+
+def _b64(content: str) -> str:
+    """Base64-encode a string the same way the GitHub API does."""
+    return base64.b64encode(content.encode()).decode()
+
+
+def _mock_response(status: int, json_data: dict | None = None) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status
+    resp.json.return_value = json_data or {}
+    return resp
+
+
+class TestFetchGithubFileContext:
+    def test_success_returns_decoded_content(self) -> None:
+        content = "def foo():\n    return 42\n"
+        mock_resp = _mock_response(200, {"content": _b64(content)})
+
+        with patch("pr_reviewer.context.requests.Session") as mock_session_cls:
+            session = MagicMock()
+            session.get.return_value = mock_resp
+            mock_session_cls.return_value = session
+
+            result = fetch_github_file_context(
+                repo="owner/repo",
+                file_paths=["src/foo.py"],
+                ref="abc123",
+                token="tok",
+            )
+
+        assert result == {"src/foo.py": content}
+
+    def test_404_is_skipped_gracefully(self) -> None:
+        mock_resp = _mock_response(404)
+
+        with patch("pr_reviewer.context.requests.Session") as mock_session_cls:
+            session = MagicMock()
+            session.get.return_value = mock_resp
+            mock_session_cls.return_value = session
+
+            result = fetch_github_file_context(
+                repo="owner/repo",
+                file_paths=["deleted.py"],
+                ref="abc123",
+                token="tok",
+            )
+
+        assert result == {}
+
+    def test_network_error_is_skipped_gracefully(self) -> None:
+        with patch("pr_reviewer.context.requests.Session") as mock_session_cls:
+            session = MagicMock()
+            session.get.side_effect = requests.ConnectionError("no network")
+            mock_session_cls.return_value = session
+
+            result = fetch_github_file_context(
+                repo="owner/repo",
+                file_paths=["src/foo.py"],
+                ref="abc123",
+                token=None,
+            )
+
+        assert result == {}
+
+    def test_other_http_error_is_skipped(self) -> None:
+        mock_resp = _mock_response(500)
+
+        with patch("pr_reviewer.context.requests.Session") as mock_session_cls:
+            session = MagicMock()
+            session.get.return_value = mock_resp
+            mock_session_cls.return_value = session
+
+            result = fetch_github_file_context(
+                repo="owner/repo",
+                file_paths=["src/foo.py"],
+                ref="abc123",
+                token="tok",
+            )
+
+        assert result == {}
+
+    def test_truncation_at_max_lines(self) -> None:
+        # Build a file with more lines than the cap
+        lines = [f"line {i}" for i in range(_MAX_FILE_LINES + 50)]
+        content = "\n".join(lines)
+        mock_resp = _mock_response(200, {"content": _b64(content)})
+
+        with patch("pr_reviewer.context.requests.Session") as mock_session_cls:
+            session = MagicMock()
+            session.get.return_value = mock_resp
+            mock_session_cls.return_value = session
+
+            result = fetch_github_file_context(
+                repo="owner/repo",
+                file_paths=["big.py"],
+                ref="abc123",
+                token="tok",
+            )
+
+        assert "big.py" in result
+        truncated = result["big.py"]
+        assert f"truncated at {_MAX_FILE_LINES} lines" in truncated
+        result_lines = truncated.splitlines()
+        # Should have _MAX_FILE_LINES content lines + 1 truncation notice
+        assert len(result_lines) == _MAX_FILE_LINES + 1
+
+    def test_no_truncation_under_limit(self) -> None:
+        lines = [f"line {i}" for i in range(10)]
+        content = "\n".join(lines)
+        mock_resp = _mock_response(200, {"content": _b64(content)})
+
+        with patch("pr_reviewer.context.requests.Session") as mock_session_cls:
+            session = MagicMock()
+            session.get.return_value = mock_resp
+            mock_session_cls.return_value = session
+
+            result = fetch_github_file_context(
+                repo="owner/repo",
+                file_paths=["small.py"],
+                ref="abc123",
+                token="tok",
+            )
+
+        assert result["small.py"] == content
+
+    def test_multiple_files_partial_failure(self) -> None:
+        good_content = "x = 1\n"
+        good_resp = _mock_response(200, {"content": _b64(good_content)})
+        bad_resp = _mock_response(404)
+
+        with patch("pr_reviewer.context.requests.Session") as mock_session_cls:
+            session = MagicMock()
+            session.get.side_effect = [good_resp, bad_resp]
+            mock_session_cls.return_value = session
+
+            result = fetch_github_file_context(
+                repo="owner/repo",
+                file_paths=["good.py", "deleted.py"],
+                ref="abc123",
+                token="tok",
+            )
+
+        assert "good.py" in result
+        assert "deleted.py" not in result
+
+    def test_empty_content_field_skipped(self) -> None:
+        mock_resp = _mock_response(200, {"content": ""})
+
+        with patch("pr_reviewer.context.requests.Session") as mock_session_cls:
+            session = MagicMock()
+            session.get.return_value = mock_resp
+            mock_session_cls.return_value = session
+
+            result = fetch_github_file_context(
+                repo="owner/repo",
+                file_paths=["empty.py"],
+                ref="abc123",
+                token="tok",
+            )
+
+        assert result == {}
+
+    def test_no_token_omits_auth_header(self) -> None:
+        content = "pass\n"
+        mock_resp = _mock_response(200, {"content": _b64(content)})
+
+        with patch("pr_reviewer.context.requests.Session") as mock_session_cls:
+            session = MagicMock()
+            session.get.return_value = mock_resp
+            mock_session_cls.return_value = session
+
+            with patch.dict("os.environ", {}, clear=True):
+                result = fetch_github_file_context(
+                    repo="owner/repo",
+                    file_paths=["src/x.py"],
+                    ref="HEAD",
+                    token=None,
+                )
+
+        # Should still work — no auth header
+        assert "src/x.py" in result
+        call_kwargs = session.headers.update.call_args[0][0]
+        assert "Authorization" not in call_kwargs

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -372,10 +372,13 @@ def test_github_connection_error_handling(
 def test_github_422_skips_finding(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test that GitHub 422 responses are handled gracefully (position rejected)."""
+    """Test that GitHub 422 responses trigger fallback when fallback also fails."""
     session = _FakeSession(
         get_responses=[_FakeResponse(200, {"head": {"sha": "abc123"}})],
-        post_responses=[_FakeResponse(422, {}, text="Unprocessable Entity")],
+        post_responses=[
+            _FakeResponse(422, {}, text="Unprocessable Entity"),
+            _FakeResponse(500, {}, text="Internal Server Error"),  # fallback fails
+        ],
     )
     monkeypatch.setattr("pr_reviewer.integrations.requests.Session", lambda: session)
 
@@ -393,5 +396,102 @@ def test_github_422_skips_finding(
 
     assert report.posted == 0
     assert report.skipped == 1
-    assert len(report.errors) == 1
-    assert "rejected comment position" in report.errors[0]
+    assert any("will try fallback" in e for e in report.errors)
+    assert any("Fallback summary comment failed" in e for e in report.errors)
+
+
+def test_github_fallback_comment_on_422(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When inline comment returns 422, a fallback issue comment is posted."""
+    session = _FakeSession(
+        get_responses=[_FakeResponse(200, {"head": {"sha": "abc123"}})],
+        post_responses=[
+            _FakeResponse(422, {}, text="Unprocessable Entity"),  # inline rejected
+            _FakeResponse(201, {}),  # fallback issue comment succeeds
+        ],
+    )
+    monkeypatch.setattr("pr_reviewer.integrations.requests.Session", lambda: session)
+
+    report = post_findings(
+        platform="github",
+        result=_result(),
+        diff_text=SAMPLE_DIFF,
+        repo="owner/repo",
+        pr_number=1,
+        mr_iid=None,
+        token="github-token",
+        base_url="https://api.github.com",
+        dry_run=False,
+    )
+
+    assert report.posted == 1
+    assert report.skipped == 0
+    assert report.fallback_posted == 1
+    # "will try fallback" messages should be cleaned up
+    assert not any("will try fallback" in e for e in report.errors)
+    # Verify fallback was posted to issues API
+    fallback_url, fallback_payload, _ = session.post_calls[1]
+    assert "/issues/1/comments" in fallback_url
+    assert "could not post as inline comments" in fallback_payload["body"].lower()
+
+
+def test_github_fallback_comment_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When both inline and fallback fail, errors are recorded and finding stays skipped."""
+    session = _FakeSession(
+        get_responses=[_FakeResponse(200, {"head": {"sha": "abc123"}})],
+        post_responses=[
+            _FakeResponse(422, {}, text="Unprocessable Entity"),  # inline rejected
+            _FakeResponse(500, {}, text="Internal Server Error"),  # fallback fails
+        ],
+    )
+    monkeypatch.setattr("pr_reviewer.integrations.requests.Session", lambda: session)
+
+    report = post_findings(
+        platform="github",
+        result=_result(),
+        diff_text=SAMPLE_DIFF,
+        repo="owner/repo",
+        pr_number=1,
+        mr_iid=None,
+        token="github-token",
+        base_url="https://api.github.com",
+        dry_run=False,
+    )
+
+    assert report.posted == 0
+    assert report.skipped == 1
+    assert report.fallback_posted == 0
+    assert any("Fallback summary comment failed" in e for e in report.errors)
+
+
+def test_github_no_fallback_when_all_inline_succeed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When all inline comments succeed, no issues comment is posted."""
+    session = _FakeSession(
+        get_responses=[_FakeResponse(200, {"head": {"sha": "abc123"}})],
+        post_responses=[_FakeResponse(201, {})],  # inline succeeds
+    )
+    monkeypatch.setattr("pr_reviewer.integrations.requests.Session", lambda: session)
+
+    report = post_findings(
+        platform="github",
+        result=_result(),
+        diff_text=SAMPLE_DIFF,
+        repo="owner/repo",
+        pr_number=1,
+        mr_iid=None,
+        token="github-token",
+        base_url="https://api.github.com",
+        dry_run=False,
+    )
+
+    assert report.posted == 1
+    assert report.skipped == 0
+    assert report.fallback_posted == 0
+    assert len(report.errors) == 0
+    # Only 1 POST call (the inline comment), no fallback
+    assert len(session.post_calls) == 1

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import requests
+
+from pr_reviewer.llm import OpenAICompatibleProvider
+
+SIMPLE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "summary": {"type": "string"},
+        "verdict": {"type": "string"},
+    },
+    "required": ["summary", "verdict"],
+    "additionalProperties": False,
+}
+
+
+def _make_success_response(content: dict) -> MagicMock:
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = 200
+    resp.json.return_value = {
+        "choices": [{"message": {"content": json.dumps(content)}}],
+    }
+    return resp
+
+
+def _make_error_response(status_code: int, message: str = "error") -> MagicMock:
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status_code
+    resp.text = message
+    resp.headers = {}
+    resp.json.return_value = {"error": {"message": message}}
+    return resp
+
+
+def test_json_schema_mode_included_in_payload() -> None:
+    """When json_schema is provided, payload should use response_format type=json_schema."""
+    success_resp = _make_success_response({"summary": "ok", "verdict": "looks good"})
+
+    with patch("pr_reviewer.llm.requests.post", return_value=success_resp) as mock_post:
+        provider = OpenAICompatibleProvider(api_key="test-key")
+        provider.complete_json(
+            model="gpt-4",
+            system_prompt="You are a reviewer.",
+            user_prompt="Review this.",
+            json_schema=SIMPLE_SCHEMA,
+        )
+
+    sent_payload = mock_post.call_args[1]["json"]
+    assert sent_payload["response_format"]["type"] == "json_schema"
+    assert sent_payload["response_format"]["json_schema"]["name"] == "review_result"
+    assert sent_payload["response_format"]["json_schema"]["strict"] is True
+    assert sent_payload["response_format"]["json_schema"]["schema"] == SIMPLE_SCHEMA
+
+
+def test_json_object_fallback_when_no_schema() -> None:
+    """When json_schema is not provided, payload should use response_format type=json_object."""
+    success_resp = _make_success_response({"summary": "ok", "verdict": "looks good"})
+
+    with patch("pr_reviewer.llm.requests.post", return_value=success_resp) as mock_post:
+        provider = OpenAICompatibleProvider(api_key="test-key")
+        provider.complete_json(
+            model="gpt-4",
+            system_prompt="You are a reviewer.",
+            user_prompt="Review this.",
+        )
+
+    sent_payload = mock_post.call_args[1]["json"]
+    assert sent_payload["response_format"] == {"type": "json_object"}
+
+
+def test_graceful_fallback_on_400() -> None:
+    """If json_schema mode returns 400, retry with json_object and succeed."""
+    import copy
+
+    error_resp = _make_error_response(400, "json_schema not supported")
+    success_resp = _make_success_response({"summary": "ok", "verdict": "looks good"})
+
+    captured_payloads: list[dict] = []
+
+    def _capture_post(*args, **kwargs):
+        captured_payloads.append(copy.deepcopy(kwargs.get("json", {})))
+        if len(captured_payloads) == 1:
+            return error_resp
+        return success_resp
+
+    with patch("pr_reviewer.llm.requests.post", side_effect=_capture_post):
+        provider = OpenAICompatibleProvider(api_key="test-key", max_retries=3)
+        result = provider.complete_json(
+            model="gpt-4",
+            system_prompt="You are a reviewer.",
+            user_prompt="Review this.",
+            json_schema=SIMPLE_SCHEMA,
+        )
+
+    assert result == json.dumps({"summary": "ok", "verdict": "looks good"})
+    assert len(captured_payloads) == 2
+
+    # First call should have used json_schema
+    assert captured_payloads[0]["response_format"]["type"] == "json_schema"
+
+    # Second call should have fallen back to json_object
+    assert captured_payloads[1]["response_format"] == {"type": "json_object"}

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -47,7 +47,9 @@ class FakeProvider:
         self._idx = 0
         self.prompts: list[str] = []
 
-    def complete_json(self, *, model: str, system_prompt: str, user_prompt: str) -> str:
+    def complete_json(
+        self, *, model: str, system_prompt: str, user_prompt: str, json_schema: dict | None = None
+    ) -> str:
         self.prompts.append(user_prompt)
         response = self._responses[self._idx]
         self._idx += 1
@@ -61,7 +63,9 @@ class FailingProvider:
         self._error_message = error_message
         self.call_count = 0
 
-    def complete_json(self, *, model: str, system_prompt: str, user_prompt: str) -> str:
+    def complete_json(
+        self, *, model: str, system_prompt: str, user_prompt: str, json_schema: dict | None = None
+    ) -> str:
         self.call_count += 1
         raise LLMError(self._error_message)
 
@@ -414,7 +418,7 @@ def test_multi_pass_partial_failure() -> None:
         def __init__(self):
             self.call_count = 0
 
-        def complete_json(self, *, model, system_prompt, user_prompt):
+        def complete_json(self, *, model, system_prompt, user_prompt, json_schema=None):
             self.call_count += 1
             if self.call_count == 1:
                 # First pass succeeds

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -448,3 +448,27 @@ def test_multi_pass_partial_failure() -> None:
     assert len(result.findings) >= 1
     assert "correctness" in result.passes_run
     assert "performance" in result.passes_run
+
+
+def test_review_with_file_context_included_in_prompt(sample_diff: str) -> None:
+    """File context should appear in the user_prompt passed to the LLM."""
+    captured_prompts: list[str] = []
+
+    class CapturingProvider:
+        def complete_json(self, *, model: str, system_prompt: str, user_prompt: str, json_schema=None) -> str:
+            captured_prompts.append(user_prompt)
+            return '{"summary": "ok", "verdict": "looks good", "findings": []}'
+
+    reviewer = PRReviewer(CapturingProvider())
+    # sample_diff touches app/main.py — use that as the context key so it matches stats.files
+    file_context = {"app/main.py": "def foo():\n    return 42\n"}
+    reviewer.review(
+        diff_text=sample_diff,
+        model="gpt-4.1-mini",
+        file_context=file_context,
+    )
+
+    assert captured_prompts, "No LLM calls were made"
+    assert "app/main.py" in captured_prompts[0], "File context not injected into prompt"
+    assert "def foo():" in captured_prompts[0], "File content not in prompt"
+    assert "File context" in captured_prompts[0], "Context label not in prompt"


### PR DESCRIPTION
Fixes all three items listed in the README's 'Known limitations' section.

## Fix 1 — Full file context in prompts
The model previously only saw the diff hunk. It now automatically fetches the complete current content of every changed file from the GitHub API and injects it into the prompt. This lets the model reason about imports, callers, and code outside the changed lines — the most common source of missed bugs.

- New `pr_reviewer/context.py`: `fetch_github_file_context()` fetches files via the GitHub Contents API, base64-decodes, truncates at 300 lines per file
- Context is injected into `_build_user_prompt` when provided, with a clear label and capped at 10 files per chunk
- CLI: context is fetched automatically when `--post github`, `--repo`, and `--pr` are all set. Resolves the PR head SHA for accuracy. `--no-context` flag disables it.
- Action: inherits automatically since `--repo` and `--pr` are already passed

## Fix 2 — JSON schema structured output
Previously used `response_format: {"type": "json_object"}` which only enforces valid JSON, not the expected structure. Now passes a full JSON schema via `response_format: {"type": "json_schema", ...}` — this is enforced by the model at generation time, eliminating parse failures.

- `REVIEW_JSON_SCHEMA` and `SYNTHESIS_JSON_SCHEMA` constants defined in `reviewer.py`
- Passed through `_run_pass` → `complete_json`
- Graceful fallback: if provider returns 400 (doesn't support json_schema mode), retries once with `json_object` — compatible with all OpenAI-compatible providers

## Fix 3 — Fallback comment when inline position is rejected
When GitHub returns 422 (position stale after a new push), findings were silently dropped. Now they're collected and posted as a single PR-level summary comment via the Issues API instead — so no finding is ever lost.

- Tracks 422-rejected findings during the posting loop
- Posts one consolidated fallback comment to `/repos/{owner}/{repo}/issues/{pr_number}/comments`
- `PostingReport` gains a `fallback_posted` counter
- README updated to reflect these are fixed

## Tests
- 61 → 77 tests (all passing, ruff clean)
- New: `tests/test_context.py` (8 tests), `tests/test_llm.py` (new file), updated `test_integrations.py` and `test_reviewer.py`